### PR TITLE
Error handling change in HTTP requests

### DIFF
--- a/lib/bcypher.js
+++ b/lib/bcypher.js
@@ -37,7 +37,7 @@ Blockcy.prototype._get = function(url, params, cb) {
 		json: true,
 		qs: params
 	}, function (error, response, body) {
-		if (!error || response.statusCode !== 200) {
+		if (error || response.statusCode !== 200) {
 			cb(error, body || {});
 		} else {
 			cb(null, body);
@@ -66,7 +66,7 @@ Blockcy.prototype._post = function(url, params, data, cb) {
 		qs: params,
 		body: data 
 	}, function (error, response, body) {
-		if (!error || (response.statusCode !== 200 && response.statusCode !== 201)) {
+		if (error || (response.statusCode !== 200 && response.statusCode !== 201)) {
 			cb(error, body || {});
 		} else {
 			cb(null, body);
@@ -93,7 +93,7 @@ Blockcy.prototype._del = function(url, params, cb) {
 		json: true,
 		qs: params
 	}, function (error, response, body) {
-		if (!error || response.statusCode !== 204) {
+		if (error || response.statusCode !== 204) {
 			cb(error, body || {});
 		} else {
 			cb(null, body);


### PR DESCRIPTION
When an error occurs, and blockcypher and response is `undefined`, this occurs.

![](https://i.gyazo.com/45149d1fe39110108b97accecef19a08.png)

`error` should be checked if it _does_ exist, no?
