### PR TITLE
Updated interface to allow second optional param to be a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ function printResponse(err, data) {
 //get chain info
 bcapi.getChain(printResponse);
 //get block height without any optional URL params
-bcapi.getBlock(300000, {}, printResponse);
+bcapi.getBlock(300000, printResponse);
 //get block height with an optional "txstart" param, as outlined in docs here: http://dev.blockcypher.com/
 bcapi.getBlock(300000, {txstart:2}, printResponse);
 

--- a/lib/bcypher.js
+++ b/lib/bcypher.js
@@ -64,7 +64,7 @@ Blockcy.prototype._post = function(url, params, data, cb) {
 		strictSSL:true,
 		json: true,
 		qs: params,
-		body: data 
+		body: data
 	}, function (error, response, body) {
 		if (error || (response.statusCode !== 200 && response.statusCode !== 201)) {
 			cb(error, body || {});
@@ -118,12 +118,16 @@ Blockcy.prototype.getChain = function(cb) {
  * <b>Get Block</b>
  * Get info about a block you're querying under your object's coin/chain, with additional parameters. Can use either block height or hash.
  * @param {(string|number)}    hh         Hash or height of the block you're querying.
- * @param {Object}             params     Optional URL parameters.
+ * @param {Object}             [params]   Optional URL parameters.
  * @callback cb
  * @memberof Blockcy
  * @method getBlock
  */
 Blockcy.prototype.getBlock = function(hh, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
 	this._get('/blocks/' + hh, params, function(error, body) {
 		cb(error, body);
 	});
@@ -133,12 +137,16 @@ Blockcy.prototype.getBlock = function(hh, params, cb) {
  * <b>Get Addr Bal</b>
  * Get balance information about an address.
  * @param {(string|number)}    addr       Address you're querying.
- * @param {Object}             params     Optional URL parameters.
+ * @param {Object}             [params]   Optional URL parameters.
  * @callback cb
  * @memberof Blockcy
  * @method getAddrBal
  */
 Blockcy.prototype.getAddrBal = function(addr, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
 	this._get('/addrs/' + addr + '/balance', params, function(error, body) {
 		cb(error, body);
 	});
@@ -148,12 +156,16 @@ Blockcy.prototype.getAddrBal = function(addr, params, cb) {
  * <b>Get Addr</b>
  * Get information about an address, including concise transaction references.
  * @param {(string|number)}    addr       Address you're querying.
- * @param {Object}             params     Optional URL parameters.
+ * @param {Object}             [params]   Optional URL parameters.
  * @callback cb
  * @memberof Blockcy
  * @method getAddr
  */
 Blockcy.prototype.getAddr = function(addr, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
 	this._get('/addrs/' + addr, params, function(error, body) {
 		cb(error, body);
 	});
@@ -163,12 +175,16 @@ Blockcy.prototype.getAddr = function(addr, params, cb) {
  * <b>Get Addr Full</b>
  * Get information about an address, including full transactions.
  * @param {(string|number)}    addr       Address you're querying.
- * @param {Object}             params     Optional URL parameters.
+ * @param {Object}             [params]   Optional URL parameters.
  * @callback cb
  * @memberof Blockcy
  * @method getAddrFull
  */
 Blockcy.prototype.getAddrFull = function(addr, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
 	this._get('/addrs/' + addr + '/full', params, function(error, body) {
 		cb(error, body);
 	});
@@ -290,7 +306,7 @@ Blockcy.prototype.getHDWallet = function(name, cb) {
  * Add array of addresses to named wallet.
  * @callback cb
  * @param {string}     name    Name of the wallet you're querying.
- * @param {string[]}   addrs   Array of addresses you're adding. 
+ * @param {string[]}   addrs   Array of addresses you're adding.
  * @memberof Blockcy
  * @method addAddrWallet
  */
@@ -362,11 +378,15 @@ Blockcy.prototype.genAddrWallet = function(name, cb) {
  * Derive an address in named HD wallet.
  * @callback cb
  * @param {string}     name      Name of the wallet you're querying.
- * @param {Object}     params    Optional URL parameters. 
+ * @param {Object}     [params]  Optional URL parameters.
  * @memberof Blockcy
  * @method deriveAddrHDWallet
  */
 Blockcy.prototype.deriveAddrHDWallet = function(name, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
 	this._post('/wallets/hd/' + name + '/addresses/derive', params, {}, function(error, body) {
 		cb(error, body);
 	});


### PR DESCRIPTION
This pull request resolves the following issue: https://github.com/blockcypher/node-client/issues/8

Basically, if the second param is optional, allow it to be a callback function.
