### PR TITLE
Replace xtend with Object.assign

### DIFF
--- a/lib/bcypher.js
+++ b/lib/bcypher.js
@@ -1,5 +1,4 @@
 var request = require('request');
-var xtend = require('xtend');
 
 const URL_ROOT = 'https://api.blockcypher.com/v1/';
 
@@ -30,7 +29,7 @@ module.exports = Blockcy;
  */
 Blockcy.prototype._get = function(url, params, cb) {
 	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = xtend(params, {token:this.token});
+	params = Object.assign({}, params, {token: this.token});
 	request.get({
 		url:urlr,
 		strictSSL:true,
@@ -58,7 +57,7 @@ Blockcy.prototype._get = function(url, params, cb) {
  */
 Blockcy.prototype._post = function(url, params, data, cb) {
 	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = xtend(params, {token:this.token});
+	params = Object.assign({}, params, {token:this.token});
 	request.post({
 		url:urlr,
 		strictSSL:true,
@@ -86,7 +85,7 @@ Blockcy.prototype._post = function(url, params, data, cb) {
  */
 Blockcy.prototype._del = function(url, params, cb) {
 	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = xtend(params, {token:this.token});
+	params = Object.assign({}, params, {token: this.token});
 	request.del({
 		url:urlr,
 		strictSSL:true,

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "version"       : "0.2.0",
   "description"   : "A REST API client for BlockCypher",
 	"repository"    : "https://github.com/blockcypher/node-client",
-	"license"       : "MIT",
+  "license"       : "MIT",
+  "engines"       : {
+    "node"        : ">=4.0.0"
+  },
   "dependencies"  : {
-    "request"     : "^2.67.0",
-    "xtend"       : "^4.0.1"
+    "request"     : "^2.67.0"
 	}
 }


### PR DESCRIPTION
* Object.assign is supported in first Major release of Node and can replace xtend
* Updated package.json to specify minimum node version
* Updated package.json to remove xtend

Reference #10 

See docs on [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)
