### PR TITLE
Get Addresses from HD Wallet with params

### DIFF
--- a/lib/bcypher.js
+++ b/lib/bcypher.js
@@ -334,11 +334,16 @@ Blockcy.prototype.getAddrsWallet = function(name, cb) {
  * Get array of addresses from named HD wallet.
  * @callback cb
  * @param {string}     name    Name of the HD wallet you're querying.
+ * @param {Object}     [params]  Optional URL parameters.
  * @memberof Blockcy
  * @method getAddrsHDWallet
  */
-Blockcy.prototype.getAddrsHDWallet = function(name, cb) {
-	this._get('/wallets/hd/' + name + '/addresses', {}, function(error, body) {
+Blockcy.prototype.getAddrsHDWallet = function(name, params, cb) {
+	if(typeof params === 'function') {
+			cb = params;
+			params = {};
+	}
+	this._get('/wallets/hd/' + name + '/addresses', params, function(error, body) {
 		cb(error, body);
 	});
 };


### PR DESCRIPTION
It allows the user to add parameters like `used` or `non-zero` which is available for HD wallet.