### PR TITLE
replaced 'request-js' to 'superagent' lib

### DIFF
--- a/lib/bcypher.js
+++ b/lib/bcypher.js
@@ -1,4 +1,4 @@
-var request = require('request');
+var request = require('superagent');
 
 const URL_ROOT = 'https://api.blockcypher.com/v1/';
 
@@ -10,9 +10,9 @@ const URL_ROOT = 'https://api.blockcypher.com/v1/';
  * @param {string}    token   Your BlockCypher API Token.
  */
 var Blockcy = function(coin, chain, token) {
-	this.coin = coin;
-	this.chain = chain;
-	this.token = token;
+  this.coin = coin;
+  this.chain = chain;
+  this.token = token;
 };
 
 module.exports = Blockcy;
@@ -28,20 +28,18 @@ module.exports = Blockcy;
  * @method            get
  */
 Blockcy.prototype._get = function(url, params, cb) {
-	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = Object.assign({}, params, {token: this.token});
-	request.get({
-		url:urlr,
-		strictSSL:true,
-		json: true,
-		qs: params
-	}, function (error, response, body) {
-		if (error || response.statusCode !== 200) {
-			cb(error, body || {});
-		} else {
-			cb(null, body);
-		}
-	});
+  var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
+  params = Object.assign({}, params, { token: this.token });
+  request
+    .get(urlr)
+    .query(params)
+    .end(function (error, response) {
+      if (error || response && response.statusCode !== 200) {
+        cb(error && error.response, response && response.body || {});
+      } else {
+        cb(null, response && response.body);
+      }
+    });
 };
 
 /**
@@ -56,21 +54,19 @@ Blockcy.prototype._get = function(url, params, cb) {
  * @method            post
  */
 Blockcy.prototype._post = function(url, params, data, cb) {
-	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = Object.assign({}, params, {token:this.token});
-	request.post({
-		url:urlr,
-		strictSSL:true,
-		json: true,
-		qs: params,
-		body: data
-	}, function (error, response, body) {
-		if (error || (response.statusCode !== 200 && response.statusCode !== 201)) {
-			cb(error, body || {});
-		} else {
-			cb(null, body);
-		}
-	});
+  var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
+  params = Object.assign({}, params, { token:this.token });
+  request
+    .post(urlr)
+    .query(params)
+    .send(data)
+    .end(function (error, response) {
+      if (error || (response && response.statusCode !== 200 && response.statusCode !== 201)) {
+        cb(error && error.response, response && response.body || {});
+      } else {
+        cb(null, response && response.body);
+      }
+    });
 };
 
 /**
@@ -84,20 +80,18 @@ Blockcy.prototype._post = function(url, params, data, cb) {
  * @method            get
  */
 Blockcy.prototype._del = function(url, params, cb) {
-	var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
-	params = Object.assign({}, params, {token: this.token});
-	request.del({
-		url:urlr,
-		strictSSL:true,
-		json: true,
-		qs: params
-	}, function (error, response, body) {
-		if (error || response.statusCode !== 204) {
-			cb(error, body || {});
-		} else {
-			cb(null, body);
-		}
-	});
+  var urlr = URL_ROOT + this.coin + '/' + this.chain + url;
+  params = Object.assign({}, params, { token: this.token });
+  request
+    .del(urlr)
+    .query(params)
+    .end(function (error, response) {
+      if (error || response && response.statusCode !== 204) {
+        cb(error && error.response, response.body || {});
+      } else {
+        cb(null, response && response.body);
+      }
+    });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name"          : "blockcypher",
-  "main"          : "./lib/bcypher.js",
-  "version"       : "0.2.0",
-  "description"   : "A REST API client for BlockCypher",
-	"repository"    : "https://github.com/blockcypher/node-client",
-  "license"       : "MIT",
-  "engines"       : {
-    "node"        : ">=4.0.0"
+  "name": "blockcypher",
+  "main": "./lib/bcypher.js",
+  "version": "0.2.0",
+  "description": "A REST API client for BlockCypher",
+  "repository": "https://github.com/blockcypher/node-client",
+  "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
   },
-  "dependencies"  : {
-    "request"     : "^2.67.0"
-	}
+  "dependencies": {
+    "superagent": "^3.8.2"
+  }
 }


### PR DESCRIPTION
Expected: the library can be used in the browser
dependency 'request.js' can be used only on the back-end side without issues, by replacing 'request.js' to 'superagent' we have achieved that 'blockcypher' can be used in both server and browser